### PR TITLE
Google Groups subscription links

### DIFF
--- a/docs/alumni.md
+++ b/docs/alumni.md
@@ -3,12 +3,12 @@ layout: page
 title: Alumni
 nav_enabled: true
 nav_order: 9
-last_modified_date: 2024-08-09
+last_modified_date: 2024-08-11
 ---
 
 We have a long tradition of former SPHS students that return to assist, passing down what they've learned in tech, school, and industry to current students and advisors alike.
 
-Alumni can join the [crew alumni](https://groups.google.com/forum/#!forum/crew-alumni) list on Google Groups. If you don't have a Google account associated with your email, [contact us](contact.html) to sign up.
+Alumni can join the [crew alumni](https://groups.google.com/forum/#!forum/crew-alumni) list on Google Groups. If you don't have a Google account associated with your email, [send an email](mailto:crew-alumni+subscribe@googlegroups.com) to sign up.
 
 ## Manifesto
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -2,7 +2,7 @@
 layout: page
 title: Contact Us
 nav_enabled: true
-last_modified_date: 2024-06-08
+last_modified_date: 2024-08-11
 ---
 
 # Contact Us
@@ -18,7 +18,7 @@ Student scheduling issues ought to be sent to the advisors.
 * Advisors: [staff@spcrew.org](mailto:staff@spcrew.org)
 * Webmaster: [webguru@spcrew.org](mailto:webguru@spcrew.org)
 
-You can also elect to receive [occasional email updates](https://groups.google.com/forum/#!forum/crew-announce/join) from us, usually a handful every year.
+You can also elect to receive [occasional email updates](mailto:crew-announce+subscribe@googlegroups.com) from us, usually a handful every year.
 
 Note: We do not publicize individual email addresses.
 

--- a/docs/news.md
+++ b/docs/news.md
@@ -3,7 +3,7 @@ layout: page
 title: News
 nav_enabled: true
 nav_order: 2
-last_modified_date: 2024-08-09
+last_modified_date: 2024-08-11
 ---
 
 # News
@@ -12,9 +12,9 @@ All the news that's fit to print about SPHS Tech Crew:
 
 * Our **mandatory orientation** will be scheduled in early September. More details soon. <small>Posted 08/09/24.</small>
 <!--* Our **mandatory orientation** will be Wednesday, September 6th from 5-8pm in the auditorium. Come hear about tech, what we'll be getting into this year, and go on a tour of our spaces. <small>Posted 08/29/23.</small>-->
-* We will **not** be attending Freshman Fair. Students interested in tech should pay attention to the morning announcements, join the [crew-announce](https://groups.google.com/forum/#!forum/crew-announce/join) mailing list, or stalk the [calendar](calendar.html) for news about our mandatory orientation in September. <small>Posted 06/02/2023.</small>
+* We will **not** be attending Freshman Fair. Students interested in tech should pay attention to the morning announcements, join the [crew-announce](mailto:crew-announce+subscribe@googlegroups.com) mailing list, or stalk the [calendar](calendar.html) for news about our mandatory orientation in September. <small>Posted 06/02/2023.</small>
 <!--* We are full up for this school year and cannot accept new applicants until fall 2022. <small>Posted 9/24/2021.</small>-->
 
-When in doubt, check the [calendar](calendar.html). You can also elect to receive [occasional email updates](https://groups.google.com/forum/#!forum/crew-announce/join) via Google Groups.
+When in doubt, check the [calendar](calendar.html). You can also elect to receive [occasional email updates](mailto:crew-announce+subscribe@googlegroups.com) via Google Groups.
 
 <!-- EOF -->


### PR DESCRIPTION
Use Google Groups subscription email links to allow people without Google accounts to self subscribe.